### PR TITLE
Polling URL Update

### DIFF
--- a/HNewsTab/PanelController.m
+++ b/HNewsTab/PanelController.m
@@ -220,7 +220,7 @@
 {
     NSString *newUrlString = [[request URL] absoluteString];
     
-    if(![newUrlString hasPrefix:@"http://cheeaun.github.com/hackerweb/#/"]){
+    if(![newUrlString hasPrefix:@"http://cheeaun.github.io/hackerweb/#/"]){
        
         [listener ignore];
         [[NSWorkspace sharedWorkspace] openURL:[request URL]];
@@ -238,7 +238,7 @@
 }
 
 -(void) refreshWebsite{
-    NSURL*url=[NSURL URLWithString:@"http://cheeaun.github.com/hackerweb/#/"];
+    NSURL*url=[NSURL URLWithString:@"http://cheeaun.github.io/hackerweb/#/"];
     NSURLRequest*request=[NSURLRequest requestWithURL:url];
     [[[self webview] mainFrame] loadRequest:request];
 }


### PR DESCRIPTION
Github migrated all its (non-source) pages to Github.io
HNewsTab was affected by this change. This commit updates the polling URL to point to http://cheeaun.github.io/hackerweb/#/
