### PR TITLE
HTTPS is now a requirement by the App Transport Security

### DIFF
--- a/HNewsTab/PanelController.m
+++ b/HNewsTab/PanelController.m
@@ -220,7 +220,7 @@
 {
     NSString *newUrlString = [[request URL] absoluteString];
     
-    if(![newUrlString hasPrefix:@"http://cheeaun.github.io/hackerweb/#/"]){
+    if(![newUrlString hasPrefix:@"https://cheeaun.github.io/hackerweb/#/"]){
        
         [listener ignore];
         [[NSWorkspace sharedWorkspace] openURL:[request URL]];
@@ -238,7 +238,7 @@
 }
 
 -(void) refreshWebsite{
-    NSURL*url=[NSURL URLWithString:@"http://cheeaun.github.io/hackerweb/#/"];
+    NSURL*url=[NSURL URLWithString:@"https://cheeaun.github.io/hackerweb/#/"];
     NSURLRequest*request=[NSURLRequest requestWithURL:url];
     [[[self webview] mainFrame] loadRequest:request];
 }


### PR DESCRIPTION
This commit fixes a regression introduced by El Capitan's App Transport Security which prevents the Web URL from opening within the HNWebView.
Please find the log output by the issue below:
"App Transport Security has blocked a cleartext HTTP (http://) resource load since it is insecure. Temporary exceptions can be configured via your app's Info.plist file."
